### PR TITLE
Honour versionControlProvenance.repositoryUri if defined in report

### DIFF
--- a/src/build.tsx
+++ b/src/build.tsx
@@ -100,8 +100,6 @@ const perfLoadStart = performance.now() // For telemetry.
 					// Add a versionControlProvenance if one is not already present.
 					if (!run.versionControlProvenance?.[0]) {
 						run.versionControlProvenance = [{ repositoryUri: buildProps.repository.url }];
-					} else {						
-						run.versionControlProvenance[0].repositoryUri = buildProps.repository.url;
 					}
 
 					// Metadata for use by the web component.


### PR DESCRIPTION
Currently this page will always overwrite the versionControlProvenance[0].repositoryUri.

This will overwrite and value set from the generation of the report and does not allow for scans across repos. 

A basic example is having a single pipeline to scan an generate over multiple repos