### PR TITLE
Only show 'Fix in VS Code' link for MS orgs

### DIFF
--- a/src/build.html
+++ b/src/build.html
@@ -21,6 +21,9 @@
 			font-size: 14px;
 			color: rgb(0, 120, 212);
 		}
+		.noArtifactLearnMore {
+			margin-left: 8px;
+		}
 	</style>
 </head>
 <body>        

--- a/src/build.tsx
+++ b/src/build.tsx
@@ -49,15 +49,21 @@ const perfLoadStart = performance.now() // For telemetry.
 				mode: "cors",
 				headers: headers
 			};
-			const response = await fetch(identitiesUri, options)
 
-			if (response.ok) {
-				const json = await response.json()
-				this.tenant = json.value[0].properties["Domain"].$value
-				console.log(`Got tenant: ${this.tenant}`)
-			} else {
-				console.error(`Failed to get tenant: ${identitiesUri}`)
-				console.error(`Status code: ${response.status}`)
+			try {
+				const response = await fetch(identitiesUri, options)
+
+				if (response.ok) {
+					const json = await response.json()
+					this.tenant = json.value[0].properties["Domain"].$value
+					console.log(`Got tenant: ${this.tenant}`)
+				} else {
+					console.error(`Failed to get tenant: ${identitiesUri}`)
+					console.error(`Status code: ${response.status}`)
+				}
+			} catch (e) {
+				console.error(`Exception from Identities API request: ${e.message}`)
+				AppInsights.trackException(e, null, { organization: organization })
 			}
 
 			const projectService = await SDK.getService<IProjectPageService>(CommonServiceIds.ProjectPageService)
@@ -161,7 +167,10 @@ const perfLoadStart = performance.now() // For telemetry.
 				Level: { value: ['error', 'warning'] },
 				Suppression: { value: ['unsuppressed']},
 			}} user={user} showActions={this.tenant === '72f988bf-86f1-41af-91ab-2d7cd011db47'} />
-			: <div className="full">No SARIF logs found. Logs must be placed within an Artifact named "CodeAnalysisLogs". <a href="https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml" target="_blank">Learn more</a></div>
+			: <div className="full">
+				No SARIF logs found. Logs must be placed within an Artifact named "CodeAnalysisLogs".
+				<a href="https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml" target="_blank" className='noArtifactLearnMore'>Learn more</a>
+			  </div>
 	}
 }
 

--- a/vss-extension.dev.json
+++ b/vss-extension.dev.json
@@ -3,7 +3,7 @@
 	"id": "scans-dev",
 	"name": "SARIF SAST Scans Tab DEV",
 	"public": false,
-	"version": "0.3.30",
+	"version": "0.3.49",
 	"contributions": [
 		{
 			"id": "build-tab",

--- a/vss-extension.dev.json
+++ b/vss-extension.dev.json
@@ -3,7 +3,7 @@
 	"id": "scans-dev",
 	"name": "SARIF SAST Scans Tab DEV",
 	"public": false,
-	"version": "0.3.49",
+	"version": "0.3.50",
 	"contributions": [
 		{
 			"id": "build-tab",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -14,5 +14,5 @@
 		{ "addressable": true, "path": "src", "packagePath": "/" },
 		{ "addressable": true, "path": "node_modules/@sinonjs/text-encoding/lib", "packagePath": "/" }
 	],
-	"scopes": ["vso.build", "vso.work"]
+	"scopes": ["vso.build", "vso.work", "vso.identity"]
 }

--- a/vss-extension.prod.json
+++ b/vss-extension.prod.json
@@ -2,7 +2,7 @@
 	"publisher": "sariftools",
 	"id": "scans",
 	"name": "SARIF SAST Scans Tab",
-	"version": "0.4.9",
+	"version": "0.4.10",
 	"public": true,
 	"contributions": [
 		{


### PR DESCRIPTION
This change uses the Identities api to get the org's backing AAD tenant, if any. The 'Fix in VS Code' link will only be shown for orgs backed by the MS corp tenant.