### PR TITLE
Update to a supported App Insights version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
 				"@microsoft/applicationinsights-web": "^3.1.0",
 				"@microsoft/sarif-web-component": "^0.6.0-28",
 				"@sinonjs/text-encoding": "^0.7.1",
-				"applicationinsights-js": "^1.0.21",
 				"azure-devops-extension-api": "^1.158.0",
 				"azure-devops-extension-sdk": "^2.0.11",
 				"jszip": "^3.5.0",
@@ -19,7 +18,6 @@
 				"vss-web-extension-sdk": "^5.141.0"
 			},
 			"devDependencies": {
-				"@types/applicationinsights-js": "^1.0.9",
 				"@types/jest": "^27.0.4",
 				"@types/react": "^16.8.18",
 				"@types/react-dom": "^16.8.4",
@@ -1301,12 +1299,6 @@
 			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
 			"dev": true
 		},
-		"node_modules/@types/applicationinsights-js": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@types/applicationinsights-js/-/applicationinsights-js-1.0.9.tgz",
-			"integrity": "sha512-tf2BBQFIRgaoxkii5Ys4Q2nvhPQ2PFt9FfgDc+xL7+XPi3s4ScqzRuAn8FRBCglnyzVvwEznOtdfqGREzUOkCw==",
-			"dev": true
-		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2126,12 +2118,6 @@
 			"resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-1.0.0.tgz",
 			"integrity": "sha512-OKap/l8oElrynRMEbtwubVW5M5G16LKz9Wxo0DYBmce595lao0EbmD4O82j7qo9yukVWMTDriWvgrbt6yPnb9A==",
 			"dev": true
-		},
-		"node_modules/applicationinsights-js": {
-			"version": "1.0.21",
-			"resolved": "https://registry.npmjs.org/applicationinsights-js/-/applicationinsights-js-1.0.21.tgz",
-			"integrity": "sha512-AUkkm8OWfCgbBuMe7kSAwUFpc1e2y+WisieQx/VgCS+BT/0AubmnGZ1yQ+zkENVriM9qArKNjLqTQp38x995wg==",
-			"deprecated": "This package has been moved to @microsoft/applicationinsights-web. Please install that package instead for the latest updates & features"
 		},
 		"node_modules/arch": {
 			"version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"packages": {
 		"": {
 			"dependencies": {
+				"@microsoft/applicationinsights-web": "^3.1.0",
 				"@microsoft/sarif-web-component": "^0.6.0-28",
 				"@sinonjs/text-encoding": "^0.7.1",
 				"applicationinsights-js": "^1.0.21",
@@ -1055,6 +1056,149 @@
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
 			"dev": true
 		},
+		"node_modules/@microsoft/applicationinsights-analytics-js": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.1.0.tgz",
+			"integrity": "sha512-uKME14ZE2I809PY/i+f39TlDn9aWSCFDdOkfjc1B46g2YVlqqtVBI0fQoPPPLjuSj1DDUjuXJUfjQL2rB853uw==",
+			"dependencies": {
+				"@microsoft/applicationinsights-common": "3.1.0",
+				"@microsoft/applicationinsights-core-js": "3.1.0",
+				"@microsoft/applicationinsights-shims": "3.0.1",
+				"@microsoft/dynamicproto-js": "^2.0.3",
+				"@nevware21/ts-utils": ">= 0.10.5 < 2.x"
+			},
+			"peerDependencies": {
+				"tslib": "*"
+			}
+		},
+		"node_modules/@microsoft/applicationinsights-cfgsync-js": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.1.0.tgz",
+			"integrity": "sha512-85wjyjgcH3YouuKj1uweQGaKD30w6DBGHrs57IpBR388xshuEt/JPayMfuxUUQE0s8ySyEk8k+S8sDh1aLYAZw==",
+			"dependencies": {
+				"@microsoft/applicationinsights-common": "3.1.0",
+				"@microsoft/applicationinsights-core-js": "3.1.0",
+				"@microsoft/applicationinsights-shims": "3.0.1",
+				"@microsoft/dynamicproto-js": "^2.0.3",
+				"@nevware21/ts-async": ">= 0.3.0 < 2.x",
+				"@nevware21/ts-utils": ">= 0.10.5 < 2.x"
+			},
+			"peerDependencies": {
+				"tslib": "*"
+			}
+		},
+		"node_modules/@microsoft/applicationinsights-channel-js": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.1.0.tgz",
+			"integrity": "sha512-VJUZT1FpQ5+XV3t4/AKprWiyH0gEEPDoJr6E8ZVopKoVVX/AjorkhPcZ4oDlpeEWpBeMxg+PeZOdTMKyY0atOw==",
+			"dependencies": {
+				"@microsoft/applicationinsights-common": "3.1.0",
+				"@microsoft/applicationinsights-core-js": "3.1.0",
+				"@microsoft/applicationinsights-shims": "3.0.1",
+				"@microsoft/dynamicproto-js": "^2.0.3",
+				"@nevware21/ts-async": ">= 0.3.0 < 2.x",
+				"@nevware21/ts-utils": ">= 0.10.5 < 2.x"
+			},
+			"peerDependencies": {
+				"tslib": "*"
+			}
+		},
+		"node_modules/@microsoft/applicationinsights-common": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.1.0.tgz",
+			"integrity": "sha512-PpWdCbTPsH5MSDIkHKaIBpEJcsnPcnAjlTCk+ls0DOfIB/T6bTn3TuKsDfSu/sxdLhDQiJeUXu8G3qOQ3L0nBA==",
+			"dependencies": {
+				"@microsoft/applicationinsights-core-js": "3.1.0",
+				"@microsoft/applicationinsights-shims": "3.0.1",
+				"@microsoft/dynamicproto-js": "^2.0.3",
+				"@nevware21/ts-utils": ">= 0.10.5 < 2.x"
+			},
+			"peerDependencies": {
+				"tslib": "*"
+			}
+		},
+		"node_modules/@microsoft/applicationinsights-core-js": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.1.0.tgz",
+			"integrity": "sha512-pHaZ3CQx+KdfRV3yV/xuMEvIEJ1KxlK6klnFcuz4AMXOOPeuvWy1FsUIQ/sVA97TXEDl87LqV6QDnH99bLZpMg==",
+			"dependencies": {
+				"@microsoft/applicationinsights-shims": "3.0.1",
+				"@microsoft/dynamicproto-js": "^2.0.3",
+				"@nevware21/ts-async": ">= 0.3.0 < 2.x",
+				"@nevware21/ts-utils": ">= 0.10.5 < 2.x"
+			},
+			"peerDependencies": {
+				"tslib": "*"
+			}
+		},
+		"node_modules/@microsoft/applicationinsights-dependencies-js": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.1.0.tgz",
+			"integrity": "sha512-CI1hJQ4goz71EWitRJLjU0Y+jD3boANmFDtlxCXnP5oVfNJkV5r/CZ6ufUNnNEO4EBG++bRg3PSlwBJ5mbZ14Q==",
+			"dependencies": {
+				"@microsoft/applicationinsights-common": "3.1.0",
+				"@microsoft/applicationinsights-core-js": "3.1.0",
+				"@microsoft/applicationinsights-shims": "3.0.1",
+				"@microsoft/dynamicproto-js": "^2.0.3",
+				"@nevware21/ts-async": ">= 0.3.0 < 2.x",
+				"@nevware21/ts-utils": ">= 0.10.5 < 2.x"
+			},
+			"peerDependencies": {
+				"tslib": "*"
+			}
+		},
+		"node_modules/@microsoft/applicationinsights-properties-js": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.1.0.tgz",
+			"integrity": "sha512-ABDDiqZD4y1gcS+Ggj7gyuPLClO7q053s53eBpxoYlZzQ5D7qn/A9A2AOCRrih4pSc212rdzi8TqC2iu9IWLxA==",
+			"dependencies": {
+				"@microsoft/applicationinsights-common": "3.1.0",
+				"@microsoft/applicationinsights-core-js": "3.1.0",
+				"@microsoft/applicationinsights-shims": "3.0.1",
+				"@microsoft/dynamicproto-js": "^2.0.3",
+				"@nevware21/ts-utils": ">= 0.10.5 < 2.x"
+			},
+			"peerDependencies": {
+				"tslib": "*"
+			}
+		},
+		"node_modules/@microsoft/applicationinsights-shims": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+			"integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+			"dependencies": {
+				"@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+			}
+		},
+		"node_modules/@microsoft/applicationinsights-web": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.1.0.tgz",
+			"integrity": "sha512-DfLiZNBZmIX8gaybvSxkecCKJpUvsL9BplhUb4ldJU7fq9h/lk5u+wJXny96Oy1jBbUpFKjBgfWjXjLb6owezw==",
+			"dependencies": {
+				"@microsoft/applicationinsights-analytics-js": "3.1.0",
+				"@microsoft/applicationinsights-cfgsync-js": "3.1.0",
+				"@microsoft/applicationinsights-channel-js": "3.1.0",
+				"@microsoft/applicationinsights-common": "3.1.0",
+				"@microsoft/applicationinsights-core-js": "3.1.0",
+				"@microsoft/applicationinsights-dependencies-js": "3.1.0",
+				"@microsoft/applicationinsights-properties-js": "3.1.0",
+				"@microsoft/applicationinsights-shims": "3.0.1",
+				"@microsoft/dynamicproto-js": "^2.0.3",
+				"@nevware21/ts-async": ">= 0.3.0 < 2.x",
+				"@nevware21/ts-utils": ">= 0.10.5 < 2.x"
+			},
+			"peerDependencies": {
+				"tslib": "*"
+			}
+		},
+		"node_modules/@microsoft/dynamicproto-js": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
+			"integrity": "sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==",
+			"dependencies": {
+				"@nevware21/ts-utils": ">= 0.10.4 < 2.x"
+			}
+		},
 		"node_modules/@microsoft/sarif-web-component": {
 			"version": "0.6.0-28",
 			"resolved": "https://registry.npmjs.org/@microsoft/sarif-web-component/-/sarif-web-component-0.6.0-28.tgz",
@@ -1087,6 +1231,19 @@
 				"mobx": "^4.0.0 || ^5.0.0",
 				"react": "^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0"
 			}
+		},
+		"node_modules/@nevware21/ts-async": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.4.0.tgz",
+			"integrity": "sha512-dbV826TTehQIBIJjh8GDSbwn1Z6+cnkyNbRlpcpdBPH8mROD2zabIUKqWcw9WRdTjjUIm21K+OR4DXWlAyOVTQ==",
+			"dependencies": {
+				"@nevware21/ts-utils": ">= 0.10.0 < 2.x"
+			}
+		},
+		"node_modules/@nevware21/ts-utils": {
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.10.5.tgz",
+			"integrity": "sha512-+TEvP0+l/VBR5bJZoYFV+o6aQQ1O6y80uys5AVyyCKeWvrgWu/yNydqSBQNsk4BuEfkayg7R9+HCJRRRIvptTA=="
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "1.8.6",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 		"test": "jest"
 	},
 	"dependencies": {
+		"@microsoft/applicationinsights-web": "^3.1.0",
 		"@microsoft/sarif-web-component": "^0.6.0-28",
 		"@sinonjs/text-encoding": "^0.7.1",
-		"applicationinsights-js": "^1.0.21",
 		"azure-devops-extension-api": "^1.158.0",
 		"azure-devops-extension-sdk": "^2.0.11",
 		"jszip": "^3.5.0",
@@ -21,7 +21,6 @@
 		"vss-web-extension-sdk": "^5.141.0"
 	},
 	"devDependencies": {
-		"@types/applicationinsights-js": "^1.0.9",
 		"@types/jest": "^27.0.4",
 		"@types/react": "^16.8.18",
 		"@types/react-dom": "^16.8.4",

--- a/src/build.tsx
+++ b/src/build.tsx
@@ -13,7 +13,6 @@ import * as ReactDOM from 'react-dom'
 import { Log } from 'sarif'
 import { getArtifactsFileEntries } from './build.getArtifactsFileEntries'
 
-const isProduction = self !== top
 const perfLoadStart = performance.now() // For telemetry.
 
 const appInsights = new ApplicationInsights({
@@ -22,12 +21,9 @@ const appInsights = new ApplicationInsights({
 	},
 })
 appInsights.loadAppInsights()
-
-if (isProduction) {
-	addEventListener('unhandledrejection', e => appInsights.trackException({
-		exception: e.reason
-	}))
-}
+addEventListener('unhandledrejection', e => appInsights.trackException({
+	exception: e.reason
+}))
 
 @observer class Tab extends React.Component {
 	@observable.ref logs = undefined as Log[]
@@ -162,19 +158,17 @@ if (isProduction) {
 
 			SDK.notifyLoadSucceeded()
 
-			if (isProduction) {
-				appInsights.trackPageView({
-					name: 'Build',
-					uri: undefined,
-					properties: {
-						duration: performance.now() - perfLoadStart,
-						results: logs.reduce((accum, log) => accum + log.runs.reduce((accum, run) => accum + run.results?.length ?? 0, 0), 0),
-						logs: logs.length,
-						toolNames: toolNamesSet.values(),
-						version: SDK.getExtensionContext().version,
-					},
-				})
-			}
+			appInsights.trackPageView({
+				name: 'Build',
+				uri: undefined,
+				properties: {
+					duration: performance.now() - perfLoadStart,
+					results: logs.reduce((accum, log) => accum + log.runs.reduce((accum, run) => accum + run.results?.length ?? 0, 0), 0),
+					logs: logs.length,
+					toolNames: toolNamesSet.values(),
+					version: SDK.getExtensionContext().version,
+				},
+			})
 		})()
 	}
 	render() {

--- a/src/build.tsx
+++ b/src/build.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Viewer } from '@microsoft/sarif-web-component'
-import { AppInsights } from "applicationinsights-js"
+import { ApplicationInsights } from "@microsoft/applicationinsights-web"
 import { CommonServiceIds, getClient, IProjectPageService } from 'azure-devops-extension-api'
 import { BuildRestClient, BuildServiceIds, IBuildPageDataService } from 'azure-devops-extension-api/Build'
 import * as SDK from 'azure-devops-extension-sdk'
@@ -15,6 +15,19 @@ import { getArtifactsFileEntries } from './build.getArtifactsFileEntries'
 
 const isProduction = self !== top
 const perfLoadStart = performance.now() // For telemetry.
+
+const appInsights = new ApplicationInsights({
+	config: {
+		connectionString: CONNECTION_STRING,
+	},
+})
+appInsights.loadAppInsights()
+
+if (isProduction) {
+	addEventListener('unhandledrejection', e => appInsights.trackException({
+		exception: e.reason
+	}))
+}
 
 @observer class Tab extends React.Component {
 	@observable.ref logs = undefined as Log[]
@@ -53,13 +66,13 @@ const perfLoadStart = performance.now() // For telemetry.
 					const json = await response.json()
 					this.tenant = json.value[0].properties["Domain"].$value
 				} else {
-					AppInsights.trackTrace('Failed to get tenant', {
+					appInsights.trackTrace({ message: 'Failed to get tenant' }, {
 						status: response.status.toString(),
 						message: await response.text(),
 					})
 				}
 			} catch (e) {
-				AppInsights.trackException(e)
+				appInsights.trackException({ exception: e })
 			}
 
 			const projectService = await SDK.getService<IProjectPageService>(CommonServiceIds.ProjectPageService)
@@ -69,7 +82,7 @@ const perfLoadStart = performance.now() // For telemetry.
 			const buildPageData = await buildPageDataService.getBuildPageData()
 			if (!buildPageData) {
 				SDK.notifyLoadSucceeded()
-				AppInsights.trackException(new Error('buildPageData undefined'))
+				appInsights.trackException({ exception: new Error('buildPageData undefined') })
 				return
 			}
 			const { build, definition } = buildPageData
@@ -81,7 +94,7 @@ const perfLoadStart = performance.now() // For telemetry.
 			const logTexts = await Promise.all(files.map(async file => {
 				let contents = await file.contentsPromise
 				if (contents.match(/^\uFEFF/)) {
-					AppInsights.trackTrace('BOM trimmed')
+					appInsights.trackTrace({ message: 'BOM trimmed' })
 					contents = contents.replace(/^\uFEFF/, ''); // Trim BOM to avoid 'Unexpected token ﻿ in JSON at position 0'.
 				}
 				return contents
@@ -89,13 +102,18 @@ const perfLoadStart = performance.now() // For telemetry.
 
 			const logs = logTexts.map(log => {
 				if (log === '') {
-					AppInsights.trackTrace('Empty log')
+					appInsights.trackTrace({ message: 'Empty log' })
 					return undefined
 				}
 				try {
 					return JSON.parse(log) as Log
 				} catch(e) {
-					AppInsights.trackException(e, null, { logSnippet: JSON.stringify(log.slice(0, 100)) })
+					appInsights.trackException({
+						exception: e,
+						properties: {
+							logSnippet: JSON.stringify(log.slice(0, 100))
+						}
+					})
 					return undefined
 				}
 			}).filter(log => log)
@@ -145,13 +163,17 @@ const perfLoadStart = performance.now() // For telemetry.
 			SDK.notifyLoadSucceeded()
 
 			if (isProduction) {
-				const customDimensions = {
-					results: logs.reduce((accum, log) => accum + log.runs.reduce((accum, run) => accum + run.results?.length ?? 0, 0), 0).toString(),
-					logs: logs.length.toString(),
-					toolNames: [...toolNamesSet.values()].join(' '),
-					version: SDK.getExtensionContext().version,
-				}
-				AppInsights.trackPageView('Build', undefined, customDimensions, undefined, performance.now() - perfLoadStart)
+				appInsights.trackPageView({
+					name: 'Build',
+					uri: undefined,
+					properties: {
+						duration: performance.now() - perfLoadStart,
+						results: logs.reduce((accum, log) => accum + log.runs.reduce((accum, run) => accum + run.results?.length ?? 0, 0), 0),
+						logs: logs.length,
+						toolNames: toolNamesSet.values(),
+						version: SDK.getExtensionContext().version,
+					},
+				})
 			}
 		})()
 	}
@@ -177,8 +199,4 @@ const perfLoadStart = performance.now() // For telemetry.
 	}
 }
 
-if (isProduction) {
-	AppInsights.downloadAndSetup({ instrumentationKey: INSTRUMENTATION_KEY })
-	addEventListener('unhandledrejection', e => AppInsights.trackException(e.reason))
-}
 ReactDOM.render(<Tab />, document.getElementById("app"))

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,1 +1,1 @@
-declare const INSTRUMENTATION_KEY: string
+declare const CONNECTION_STRING: string

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ const common = env => ({
 	},
 	plugins: [
 		new DefinePlugin({
-			INSTRUMENTATION_KEY: JSON.stringify(env?.INSTRUMENTATION_KEY ?? ''),
+			CONNECTION_STRING: JSON.stringify(env?.CONNECTION_STRING ?? ''),
 		})
 	],
 })
@@ -50,7 +50,7 @@ module.exports = env => [
 			port: 8080,
 			https: true,
 		},
-	},	
+	},
 	{
 		...common(env),
 		entry: path.join(__dirname, 'src', 'workItem.tsx'),


### PR DESCRIPTION
Update to App Insights 3.x and change to a connection string.

I removed the production checks as we can circumvent that by not loading the connection string in non-prod environments :).