### PR TITLE
Include missing CSS in the VSIX

### DIFF
--- a/vss-extension.dev.json
+++ b/vss-extension.dev.json
@@ -3,7 +3,7 @@
 	"id": "scans-dev",
 	"name": "SARIF SAST Scans Tab DEV",
 	"public": false,
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"contributions": [
 		{
 			"id": "build-tab",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = env => ({
 			CONNECTION_STRING: JSON.stringify(env?.CONNECTION_STRING ?? ''),
 		}),
 		new CopyWebpackPlugin({
-			patterns: [{ from: "**/*.html", context: "src" }],
+			patterns: [{ from: "**/*.{html,css}", context: "src" }],
 		}),
 	],
 })


### PR DESCRIPTION
I missed this when adding CopyWebpackPlugin because I'm used to the CSS being imported in the .tsx files themselves. I'll investigate why that's not the case later (I imagine it might be because of the ADO/VSS SDK split).