### PR TITLE
Add revisionId to versionControlProvenance in case versionControlProvenance not existing

### DIFF
--- a/src/build.tsx
+++ b/src/build.tsx
@@ -141,7 +141,10 @@ addEventListener('unhandledrejection', e => appInsights.trackException({
 				log.runs.forEach(run => {
 					// Add a versionControlProvenance if one is not already present.
 					if (!run.versionControlProvenance?.[0]) {
-						run.versionControlProvenance = [{ repositoryUri: buildProps.repository.url }];
+						run.versionControlProvenance = [{
+							repositoryUri: buildProps.repository.url,
+							revisionId: buildProps.sourceVersion,
+						}];
 					}
 
 					// Metadata for use by the web component.


### PR DESCRIPTION
Added revisionId in case no versionControlProvenance is existing in the SARIF file. With the revisionId available the generated links to the repository include the version in the query. Without the revisionId the link just points to the repo and one ends up on the revision (branch, tag, commit) that was selected last. With the revisionId set you end up on the commit that was used by the respective build.