### PR TITLE
Add support for .sarif.json files

### DIFF
--- a/src/build.getArtifactsFileEntries.ts
+++ b/src/build.getArtifactsFileEntries.ts
@@ -33,7 +33,7 @@ export async function getArtifactsFileEntries(
 					try {
 						return Object
 							.values(zip.files)
-							.filter(entry => !entry.dir && entry.name.endsWith('.sarif'))
+							.filter(entry => !entry.dir && (entry.name.endsWith('.sarif') || entry.name.endsWith('.sarif.json')))
 							.map(entry => ({
 								name:            entry.name.replace(`${artifact.name}/`, ''),
 								artifactName:    artifact.name,

--- a/src/mockBuildClient.ts
+++ b/src/mockBuildClient.ts
@@ -29,6 +29,12 @@ async function generateMockBuildArtifacts() {
 			await generateMockBuildArtifact('foo_sdl_sources',      'foo_sdl_sources.sarif'),
 			await generateMockBuildArtifact('foo_sdl_sources_bar',  'foo_sdl_sources_bar.sarif'),
 			await generateMockBuildArtifact('nonSarifArtifact',     'nonSarifArtifact.sarif'),
+			await generateMockBuildArtifact('CodeAnalysisLogs',     'CodeAnalysisLogs.sarif.json'),
+			await generateMockBuildArtifact('foo_sdl_analysis',     'foo_sdl_analysis.sarif.json'),
+			await generateMockBuildArtifact('foo_sdl_analysis_bar', 'foo_sdl_analysis_bar.sarif.json'),
+			await generateMockBuildArtifact('foo_sdl_sources',      'foo_sdl_sources.sarif.json'),
+			await generateMockBuildArtifact('foo_sdl_sources_bar',  'foo_sdl_sources_bar.sarif.json'),
+			await generateMockBuildArtifact('nonSarifArtifact',     'nonSarifArtifact.sarif.json'),
 		] 
 	}
 	return mockBuildArtifacts


### PR DESCRIPTION
Qodana produces .sarif.json artifacts, to support these I just added one more possible fileending and adjusted tests accordingly